### PR TITLE
Update V3 Routes

### DIFF
--- a/src/routes/v3/arbitrum/sc-pool-apy-history.js
+++ b/src/routes/v3/arbitrum/sc-pool-apy-history.js
@@ -198,7 +198,7 @@ async function fetchDataFromPostgres() {
         apy_7d_rewards, 
         apr_28d_rewards, 
         apy_28d_rewards
-      FROM arbitrum_mainnet.fct_core_apr 
+      FROM prod_arbitrum_mainnet.fct_core_apr_arbitrum_mainnet
       WHERE pool_id = 1 
       ORDER BY ts DESC
     )

--- a/src/routes/v3/arbitrum/sc-pool-apy.js
+++ b/src/routes/v3/arbitrum/sc-pool-apy.js
@@ -198,7 +198,7 @@ async function fetchDataFromPostgres() {
         apy_7d_rewards, 
         apr_28d_rewards, 
         apy_28d_rewards
-      FROM arbitrum_mainnet.fct_core_apr 
+      FROM prod_arbitrum_mainnet.fct_core_apr_arbitrum_mainnet
       WHERE pool_id = 1 
       ORDER BY collateral_type, ts DESC
     )

--- a/src/routes/v3/base/sc-pool-apy-history.js
+++ b/src/routes/v3/base/sc-pool-apy-history.js
@@ -165,7 +165,45 @@ module.exports = router;
 async function fetchDataFromPostgres() {
   log.debug('[v3BaseSCPoolAPYHistory] Fetching data from postgres..');
   const queryResult = await postgresClient.query(
-    'select ts, pool_id, collateral_type, collateral_value, debt, hourly_issuance, hourly_pnl, cumulative_pnl, cumulative_issuance, rewards_usd, hourly_pnl_pct, hourly_rewards_pct, apr_24h, apy_24h, apr_7d, apy_7d, apr_28d, apy_28d, apr_24h_pnl, apy_24h_pnl, apr_7d_pnl, apy_7d_pnl, apr_28d_pnl, apy_28d_pnl, apr_24h_rewards, apy_24h_rewards, apr_7d_rewards, apy_7d_rewards, apr_28d_rewards, apy_28d_rewards from base_mainnet.fct_core_apr WHERE pool_id = 1 order by ts desc limit 100000;',
+    `WITH latest_records AS (
+      SELECT
+        ts, 
+        pool_id, 
+        collateral_type, 
+        collateral_value, 
+        debt, 
+        hourly_issuance, 
+        hourly_pnl, 
+        cumulative_pnl, 
+        cumulative_issuance, 
+        rewards_usd, 
+        hourly_pnl_pct, 
+        hourly_rewards_pct, 
+        apr_24h, 
+        apy_24h, 
+        apr_7d, 
+        apy_7d, 
+        apr_28d, 
+        apy_28d, 
+        apr_24h_pnl, 
+        apy_24h_pnl, 
+        apr_7d_pnl, 
+        apy_7d_pnl, 
+        apr_28d_pnl, 
+        apy_28d_pnl, 
+        apr_24h_rewards, 
+        apy_24h_rewards, 
+        apr_7d_rewards, 
+        apy_7d_rewards, 
+        apr_28d_rewards, 
+        apy_28d_rewards
+      FROM prod_base_mainnet.fct_core_apr_base_mainnet
+      WHERE pool_id = 1 
+      ORDER BY ts DESC
+    )
+    SELECT * FROM latest_records
+    ORDER BY ts DESC
+    LIMIT 100000;`,
   );
 
   const dailyResults = queryResult.rows

--- a/src/routes/v3/base/sc-pool-apy.js
+++ b/src/routes/v3/base/sc-pool-apy.js
@@ -163,7 +163,44 @@ module.exports = router;
 async function fetchDataFromPostgres() {
   log.debug('[v3BaseSCPoolAPY] Fetching data from postgres..');
   const queryResult = await postgresClient.query(
-    'select ts, pool_id, collateral_type, collateral_value, debt, hourly_issuance, hourly_pnl, cumulative_pnl, cumulative_issuance, rewards_usd, hourly_pnl_pct, hourly_rewards_pct, apr_24h, apy_24h, apr_7d, apy_7d, apr_28d, apy_28d, apr_24h_pnl, apy_24h_pnl, apr_7d_pnl, apy_7d_pnl, apr_28d_pnl, apy_28d_pnl, apr_24h_rewards, apy_24h_rewards, apr_7d_rewards, apy_7d_rewards, apr_28d_rewards, apy_28d_rewards from base_mainnet.fct_core_apr WHERE pool_id = 1 order by ts desc limit 1;',
+    `WITH latest_records AS (
+      SELECT DISTINCT ON (collateral_type) 
+        ts, 
+        pool_id, 
+        collateral_type, 
+        collateral_value, 
+        debt, 
+        hourly_issuance, 
+        hourly_pnl, 
+        cumulative_pnl, 
+        cumulative_issuance, 
+        rewards_usd, 
+        hourly_pnl_pct, 
+        hourly_rewards_pct, 
+        apr_24h, 
+        apy_24h, 
+        apr_7d, 
+        apy_7d, 
+        apr_28d, 
+        apy_28d, 
+        apr_24h_pnl, 
+        apy_24h_pnl, 
+        apr_7d_pnl, 
+        apy_7d_pnl, 
+        apr_28d_pnl, 
+        apy_28d_pnl, 
+        apr_24h_rewards, 
+        apy_24h_rewards, 
+        apr_7d_rewards, 
+        apy_7d_rewards, 
+        apr_28d_rewards, 
+        apy_28d_rewards
+      FROM prod_base_mainnet.fct_core_apr_base_mainnet
+      WHERE pool_id = 1 
+      ORDER BY collateral_type, ts DESC
+    )
+    SELECT * FROM latest_records
+    ORDER BY ts DESC;`,
   );
 
   const {

--- a/src/routes/v3/base/snx-buyback.js
+++ b/src/routes/v3/base/snx-buyback.js
@@ -80,7 +80,13 @@ module.exports = router;
 async function fetchDataFromPostgres() {
   log.debug('[v3BaseSNXBuyback] Fetching data from postgres..');
   const queryResult = await postgresClient.query(
-    'select ts, snx_amount, usd_amount, cumulative_snx_amount, cumulative_usd_amount from base_mainnet.fct_buyback_daily;',
+    `select
+      ts,
+      snx_amount,
+      usd_amount,
+      cumulative_snx_amount,
+      cumulative_usd_amount
+    from prod_base_mainnet.fct_buyback_daily_base_mainnet;`,
   );
 
   const data = queryResult.rows.map(parseAndRenameKeys);


### PR DESCRIPTION
[This PR](https://github.com/Synthetixio/data/pull/71) in the data repo makes breaking changes to some naming conventioned in the data warehouse:
1. Schema names change from `base_mainnet` to `prod_base_mainnet` in order to support staging targets in the future
2. Tables names now include the network name to comply with dbt uniqueness checks: `fct_core_apr -> fct_core_apr_base_mainnet`

The changes here support this major upgrade, and should be coordinated with deploying these changes to the data warehouse.